### PR TITLE
Update data-wizard requirement spec

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=5.0,<6.0
 djangorestframework>=3.15.0
 # django-data-wizard does not have a PyPI release; install from GitHub
--e git+https://github.com/wq/django-data-wizard.git#egg=django-data-wizard
+data-wizard @ git+https://github.com/wq/django-data-wizard.git
 openpyxl>=3.1.0
 tablib[html,xls,xlsx]>=3.5.0


### PR DESCRIPTION
## Summary
- replace the editable `django-data-wizard` requirement with a direct reference matching the package metadata

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68d0a012b1bc83268428dfea5f542bcf