### PR TITLE
Handle preview loader errors and support login redirects

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("pmksy.urls")),
     path("datawizard/", include("data_wizard.urls")),
+    path("accounts/", include("django.contrib.auth.urls")),
 ]
 
 if settings.DEBUG:

--- a/pmksy/templates/registration/login.html
+++ b/pmksy/templates/registration/login.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Sign in &ndash; PMKSY</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; background-color: #f6f7fb; }
+        .login-card { max-width: 400px; margin: 0 auto; padding: 2rem; background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08); }
+        h1 { margin-top: 0; font-size: 1.75rem; }
+        form { display: flex; flex-direction: column; gap: 1rem; }
+        label { font-weight: bold; margin-bottom: 0.25rem; display: block; }
+        input[type="text"], input[type="password"] {
+            width: 100%;
+            padding: 0.75rem;
+            border: 1px solid #ccd3e0;
+            border-radius: 4px;
+            font-size: 1rem;
+        }
+        button {
+            padding: 0.75rem;
+            background-color: #0b5ed7;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            font-size: 1rem;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #094aa9;
+        }
+        .messages { background-color: #f8d7da; color: #842029; padding: 0.75rem; border-radius: 4px; margin-bottom: 1rem; }
+        ul.errorlist { list-style: none; padding: 0; margin: 0.5rem 0 0; color: #842029; }
+        .helptext { font-size: 0.875rem; color: #495057; }
+    </style>
+</head>
+<body>
+    <div class="login-card">
+        <h1>Sign in</h1>
+        {% if form.non_field_errors %}
+            <div class="messages" role="alert">
+                {% for error in form.non_field_errors %}
+                    <p>{{ error }}</p>
+                {% endfor %}
+            </div>
+        {% endif %}
+        <form method="post" novalidate>
+            {% csrf_token %}
+            <div>
+                <label for="id_username">Username</label>
+                {{ form.username }}
+                {% if form.username.errors %}
+                    <ul class="errorlist">
+                        {% for error in form.username.errors %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </div>
+            <div>
+                <label for="id_password">Password</label>
+                {{ form.password }}
+                {% if form.password.errors %}
+                    <ul class="errorlist">
+                        {% for error in form.password.errors %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </div>
+            {% if next %}
+                <input type="hidden" name="next" value="{{ next }}">
+            {% endif %}
+            <button type="submit">Sign in</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/pmksy/tests.py
+++ b/pmksy/tests.py
@@ -1,3 +1,100 @@
-from django.test import TestCase
+from unittest import mock
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+
+from .views import PREVIEW_ERROR_MESSAGE
+
+
+class PMKSYImportWizardPreviewTests(TestCase):
+    """Tests for PMKSY import wizard preview handling."""
+
+    def setUp(self) -> None:
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="tester",
+            email="tester@example.com",
+            password="password123",
+        )
+        self.client.force_login(self.user)
+        self.wizard_url = reverse("pmksy:wizard", kwargs={"wizard_slug": "farmers"})
+
+    def test_invalid_workbook_redirects_with_message(self) -> None:
+        """An invalid workbook should surface a helpful error message."""
+
+        class BrokenLoader:
+            def __init__(self, run):  # pragma: no cover - simple data holder
+                self.run = run
+
+            def load_iter(self):
+                raise ValueError("Unsupported workbook format")
+
+        uploaded_file = SimpleUploadedFile(
+            "invalid.xlsx",
+            b"not a real workbook",
+            content_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        )
+
+        with mock.patch(
+            "pmksy.views.data_wizard_registry.get_loader", return_value=BrokenLoader
+        ):
+            with self.assertLogs("pmksy.views", level="ERROR") as logs:
+                response = self.client.post(
+                    self.wizard_url, {"source_file": uploaded_file}, follow=True
+                )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertGreaterEqual(len(response.redirect_chain), 2)
+        self.assertEqual(response.redirect_chain[-1][0], self.wizard_url)
+
+        messages = [message.message for message in response.context["messages"]]
+        self.assertIn(PREVIEW_ERROR_MESSAGE, messages)
+
+        self.assertTrue(
+            any("Failed to generate preview" in message for message in logs.output)
+        )
+
+
+class AuthenticationFlowTests(TestCase):
+    """Ensure unauthenticated users are prompted to log in before importing."""
+
+    def setUp(self) -> None:
+        user_model = get_user_model()
+        self.password = "password123"
+        self.user = user_model.objects.create_user(
+            username="authuser",
+            email="authuser@example.com",
+            password=self.password,
+        )
+        self.import_home_url = reverse("pmksy:import-home")
+        self.login_url = reverse("login")
+
+    def test_import_home_redirects_to_login(self) -> None:
+        """Anonymous users should be redirected to the login page."""
+
+        response = self.client.get(self.import_home_url)
+
+        self.assertRedirects(
+            response,
+            f"{self.login_url}?next={self.import_home_url}",
+            fetch_redirect_response=False,
+        )
+
+        login_page = self.client.get(response.url)
+        self.assertEqual(login_page.status_code, 200)
+        self.assertContains(login_page, "Sign in")
+
+    def test_authenticated_user_can_access_import_home(self) -> None:
+        """After logging in, users should reach the import home page."""
+
+        logged_in = self.client.login(username=self.user.username, password=self.password)
+        self.assertTrue(logged_in)
+
+        response = self.client.get(self.import_home_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "PMKSY Data Import")

--- a/pmksy/views.py
+++ b/pmksy/views.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Tuple, Type
 
 from django import forms
 from django.contrib import messages
@@ -21,6 +21,45 @@ from data_wizard.sources.models import FileSource
 from .importers import REGISTRATIONS
 
 logger = logging.getLogger(__name__)
+
+
+PREVIEW_ERROR_MESSAGE = (
+    "We couldn't read the uploaded file. Please upload a supported format."
+)
+
+
+class PreviewGenerationError(Exception):
+    """Raised when a preview cannot be generated for an uploaded dataset."""
+
+
+PREVIEW_LOAD_ERRORS: Tuple[Type[BaseException], ...] = (ValueError,)
+
+try:  # pragma: no cover - optional dependency for XLS files
+    from xlrd import XLRDError  # type: ignore
+except ImportError:  # pragma: no cover - fallback when xlrd is unavailable
+    XLRDError = None  # type: ignore[assignment]
+else:  # pragma: no cover - exercised only when xlrd is installed
+    PREVIEW_LOAD_ERRORS = PREVIEW_LOAD_ERRORS + (XLRDError,)
+
+try:  # pragma: no cover - optional dependency for XLSX files
+    from openpyxl.utils.exceptions import InvalidFileException
+except ImportError:  # pragma: no cover - fallback when openpyxl is unavailable
+    InvalidFileException = None  # type: ignore[assignment]
+else:  # pragma: no cover - exercised only when openpyxl is installed
+    PREVIEW_LOAD_ERRORS = PREVIEW_LOAD_ERRORS + (InvalidFileException,)
+
+try:  # pragma: no cover - optional dependency used by data_wizard
+    import itertable.exceptions as itertable_exceptions  # type: ignore
+except ImportError:  # pragma: no cover - fallback when itertable is unavailable
+    itertable_exceptions = None  # type: ignore[assignment]
+else:  # pragma: no cover - exercised only when itertable is installed
+    _itertable_error_types: List[Type[BaseException]] = []
+    for name in ("TableError", "TableLoadError", "UnsupportedFormat"):
+        exc = getattr(itertable_exceptions, name, None)
+        if isinstance(exc, type) and issubclass(exc, BaseException):
+            _itertable_error_types.append(exc)
+    if _itertable_error_types:
+        PREVIEW_LOAD_ERRORS = PREVIEW_LOAD_ERRORS + tuple(_itertable_error_types)
 
 
 try:  # pragma: no cover - compatibility for future data_wizard releases
@@ -61,32 +100,36 @@ def get_preview_rows(run: Run, limit: int = 5) -> Tuple[List[str], List[List[str
 
     Loader = data_wizard_registry.get_loader(run.loader)
     loader = Loader(run)
-    table = loader.load_iter()
 
     headers: List[str] = []
     rows: List[List[str]] = []
 
-    if hasattr(table, "field_map") and table.field_map:
-        headers = list(table.field_map.keys())
+    try:
+        table = loader.load_iter()
 
-    iterator: Iterable = table
-    for index, row in enumerate(iterator):
-        if hasattr(row, "_asdict"):
-            data = row._asdict()
-        elif isinstance(row, dict):
-            data = row
-        elif isinstance(row, (list, tuple)):
-            data = {str(i): value for i, value in enumerate(row)}
-        else:
-            data = {"value": row}
+        if hasattr(table, "field_map") and table.field_map:
+            headers = list(table.field_map.keys())
 
-        if not headers:
-            headers = list(data.keys())
+        iterator: Iterable = table
+        for index, row in enumerate(iterator):
+            if hasattr(row, "_asdict"):
+                data = row._asdict()
+            elif isinstance(row, dict):
+                data = row
+            elif isinstance(row, (list, tuple)):
+                data = {str(i): value for i, value in enumerate(row)}
+            else:
+                data = {"value": row}
 
-        rows.append([str(data.get(column, "")) for column in headers])
+            if not headers:
+                headers = list(data.keys())
 
-        if index + 1 >= limit:
-            break
+            rows.append([str(data.get(column, "")) for column in headers])
+
+            if index + 1 >= limit:
+                break
+    except PREVIEW_LOAD_ERRORS as exc:
+        raise PreviewGenerationError("Unable to load preview data") from exc
 
     return headers, rows
 
@@ -125,7 +168,14 @@ class PMKSYImportWizard(LoginRequiredMixin, BaseImportWizard):
         run_id = request.GET.get("run")
         if run_id:
             run = self._get_user_run(run_id)
-            headers, rows = get_preview_rows(run)
+            try:
+                headers, rows = get_preview_rows(run)
+            except PreviewGenerationError:
+                logger.exception("Failed to generate preview for run %s", run.pk)
+                messages.error(request, PREVIEW_ERROR_MESSAGE)
+                return redirect(
+                    reverse("pmksy:wizard", kwargs={"wizard_slug": self.wizard_slug})
+                )
             context = {
                 "wizard": self.wizard_config,
                 "run": run,


### PR DESCRIPTION
## Summary
- wrap the data preview loader in targeted exception handling and introduce a reusable error message when preview generation fails
- ensure the wizard view logs loader failures, flashes an error message, and redirects back to the upload form instead of crashing
- add a regression test that simulates an invalid workbook upload to confirm the preview error is surfaced gracefully
- expose Django's built-in authentication URLs and provide a login template so `/accounts/login/` renders correctly
- add authentication flow regression tests to ensure anonymous users are redirected to log in before accessing the import wizard

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d0a874a3b88326b00707ecc40a1687