### PR TITLE
Add UUID-safe Data Wizard import path and regression test

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -132,6 +132,16 @@ REST_FRAMEWORK = {
     ],
 }
 
+DATA_WIZARD = {
+    "AUTO_IMPORT_TASKS": (
+        "data_wizard.tasks.check_serializer",
+        "data_wizard.tasks.check_iter",
+        "data_wizard.tasks.check_columns",
+        "data_wizard.tasks.check_row_identifiers",
+        "pmksy.wizard_tasks.import_data",
+    )
+}
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 

--- a/pmksy/tests/test_uuid_import.py
+++ b/pmksy/tests/test_uuid_import.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import tempfile
+from urllib.parse import parse_qs, urlparse
+
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from data_wizard.models import Identifier, Run
+
+from ..models import Farmer
+
+
+class FarmersImportUUIDTests(TestCase):
+    """Regression tests for importing Farmers data with UUID primary keys."""
+
+    def setUp(self) -> None:
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="uuidtester",
+            email="uuidtester@example.com",
+            password="password123",
+        )
+        self.client.force_login(self.user)
+        self.wizard_url = reverse("pmksy:wizard", kwargs={"wizard_slug": "farmers"})
+
+    def test_import_handles_uuid_primary_keys(self) -> None:
+        """The import task should not overflow when models use UUID PKs."""
+
+        Identifier.objects.create(
+            serializer="Farmers",
+            name="name",
+            field="name",
+            resolved=True,
+        )
+
+        with tempfile.TemporaryDirectory() as media_root, override_settings(
+            MEDIA_ROOT=media_root
+        ):
+            upload = SimpleUploadedFile(
+                "farmers.csv",
+                "name\nTest Farmer\n".encode("utf-8"),
+                content_type="text/csv",
+            )
+            response = self.client.post(self.wizard_url, {"source_file": upload})
+
+            self.assertEqual(response.status_code, 302)
+            redirect_url = response["Location"]
+            run_id = parse_qs(urlparse(redirect_url).query)["run"][0]
+
+            preview_response = self.client.get(redirect_url)
+            self.assertEqual(preview_response.status_code, 200)
+
+            confirm_response = self.client.post(
+                self.wizard_url, {"run_id": run_id}, follow=True
+            )
+
+        self.assertEqual(confirm_response.status_code, 200)
+        self.assertIn("Import Complete", confirm_response.content.decode())
+
+        self.assertEqual(Farmer.objects.count(), 1)
+        run = Run.objects.get(pk=int(run_id))
+        record = run.record_set.get()
+        self.assertTrue(record.success)
+        self.assertIsNone(record.object_id)
+        self.assertIsNotNone(record.content_type)
+        self.assertEqual(record.content_type.model, "farmer")
+        self.assertEqual(run.record_count, 1)

--- a/pmksy/tests/test_views.py
+++ b/pmksy/tests/test_views.py
@@ -5,7 +5,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import reverse
 
-from .views import PREVIEW_ERROR_MESSAGE
+from ..views import PREVIEW_ERROR_MESSAGE
 
 
 class PMKSYImportWizardPreviewTests(TestCase):

--- a/pmksy/wizard_tasks.py
+++ b/pmksy/wizard_tasks.py
@@ -1,0 +1,129 @@
+"""Custom data import tasks for PMKSY."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import models
+
+from data_wizard.tasks import (
+    get_rows,
+    import_complete,
+    import_row,
+    reversion,
+    wizard_task,
+)
+
+
+@wizard_task(label="Importing Data...", url_path="data", use_async=True)
+def import_data(run):
+    """Import all parseable data from the dataset instance's Iter class."""
+    if reversion:
+        with reversion.create_revision():
+            reversion.set_user(run.user)
+            reversion.set_comment("Imported via %s" % run)
+            result = _do_import(run)
+    else:
+        result = _do_import(run)
+    return result
+
+
+def _do_import(run):
+    run.add_event("do_import")
+
+    # Loop through table rows and add each record
+    table = run.load_iter()
+    rows = len(table)
+    skipped: list[dict[str, Any]] = []
+
+    if table.tabular:
+
+        def rownum(i):
+            return i + table.start_row
+
+    else:
+
+        def rownum(i):
+            return i
+
+    for i, row in enumerate(get_rows(run)):
+        # Update state (for status() on view)
+        run.send_progress(
+            {
+                "message": "Importing Data...",
+                "stage": "data",
+                "current": i,
+                "total": rows,
+                "skipped": skipped,
+            }
+        )
+
+        # Create report, capturing any errors
+        obj, error = import_row(run, i, row)
+        if error:
+            success = False
+            fail_reason = error
+            skipped.append({"row": rownum(i) + 1, "reason": fail_reason})
+        else:
+            success = True
+            fail_reason = None
+
+        # Record relationship between data source and resulting report (or
+        # skipped record), including specific cell range.
+        record = run.record_set.model(
+            run=run,
+            row=rownum(i),
+            success=success,
+            fail_reason=fail_reason,
+        )
+        _set_record_object(record, obj)
+        record.save()
+
+    # Send completion signal (in case any server handlers are registered)
+    status = {"current": i + 1, "total": rows, "skipped": skipped}
+    run.add_event("import_complete")
+    run.record_count = run.record_set.filter(success=True).count()
+    run.save()
+    run.send_progress(status, state="SUCCESS")
+    import_complete.send(sender=import_data, run=run, status=status)
+
+    return status
+
+
+def _set_record_object(record, obj: Any) -> None:
+    """Attach ``obj`` to ``record`` while gracefully handling UUID keys."""
+
+    if not isinstance(obj, models.Model):
+        return
+
+    if _has_uuid_primary_key(obj):
+        record.content_type = ContentType.objects.get_for_model(
+            obj, for_concrete_model=False
+        )
+        record.object_id = None
+    else:
+        record.content_object = obj
+
+
+def _has_uuid_primary_key(obj: models.Model) -> bool:
+    """Return ``True`` if ``obj`` is backed by a UUID primary key."""
+
+    pk_field = obj._meta.pk
+    if isinstance(pk_field, models.UUIDField):
+        return True
+
+    pk_value = getattr(obj, pk_field.attname, None)
+    if isinstance(pk_value, uuid.UUID):
+        return True
+
+    if isinstance(pk_value, str):
+        try:
+            uuid.UUID(pk_value)
+        except (TypeError, ValueError, AttributeError):
+            return False
+        else:
+            return True
+
+    return False


### PR DESCRIPTION
## Summary
- add a PMKSY-specific Data Wizard import task that skips storing UUIDs in Record.object_id
- configure AUTO_IMPORT_TASKS to use the new import implementation
- migrate the test suite into a package and add a regression test covering Farmers imports with UUID primary keys

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d0b2f2b3c48326bdaafbc5acd9d1d6