### PR TITLE
Fix preview field map lookups for import wizard

### DIFF
--- a/pmksy/tests/test_uuid_import.py
+++ b/pmksy/tests/test_uuid_import.py
@@ -52,6 +52,7 @@ class FarmersImportUUIDTests(TestCase):
 
             preview_response = self.client.get(redirect_url)
             self.assertEqual(preview_response.status_code, 200)
+            self.assertIn("Test Farmer", preview_response.content.decode())
 
             confirm_response = self.client.post(
                 self.wizard_url, {"run_id": run_id}, follow=True

--- a/pmksy/views.py
+++ b/pmksy/views.py
@@ -102,6 +102,7 @@ def get_preview_rows(run: Run, limit: int = 5) -> Tuple[List[str], List[List[str
     loader = Loader(run)
 
     headers: List[str] = []
+    lookup_keys: List[str] = []
     rows: List[List[str]] = []
 
     try:
@@ -109,6 +110,7 @@ def get_preview_rows(run: Run, limit: int = 5) -> Tuple[List[str], List[List[str
 
         if hasattr(table, "field_map") and table.field_map:
             headers = list(table.field_map.keys())
+            lookup_keys = [table.field_map[h] for h in headers]
 
         iterator: Iterable = table
         for index, row in enumerate(iterator):
@@ -123,8 +125,19 @@ def get_preview_rows(run: Run, limit: int = 5) -> Tuple[List[str], List[List[str
 
             if not headers:
                 headers = list(data.keys())
+                lookup_keys = list(headers)
 
-            rows.append([str(data.get(column, "")) for column in headers])
+            row_values: List[str] = []
+            for column_index, column in enumerate(headers):
+                lookup_key = (
+                    lookup_keys[column_index]
+                    if column_index < len(lookup_keys)
+                    else column
+                )
+                value = data.get(lookup_key, data.get(column, ""))
+                row_values.append(str(value))
+
+            rows.append(row_values)
 
             if index + 1 >= limit:
                 break


### PR DESCRIPTION
## Summary
- ensure the preview builder respects field_map lookups when collecting row values
- add a regression test verifying the preview includes uploaded data

## Testing
- python manage.py test pmksy.tests.test_uuid_import

------
https://chatgpt.com/codex/tasks/task_e_68d0b8fa1c7c8326a3a3adf588b21d8f