### PR TITLE
Allow importing farmer relationships by name

### DIFF
--- a/pmksy/serializers.py
+++ b/pmksy/serializers.py
@@ -5,6 +5,49 @@ from rest_framework import serializers
 from . import models
 
 
+class FarmerByNameField(serializers.RelatedField):
+    """Serializer field that resolves farmers by their name."""
+
+    default_error_messages = {
+        "blank": "Please provide a farmer name.",
+        "does_not_exist": "Farmer with name '{value}' does not exist.",
+        "invalid": "Invalid farmer name provided.",
+        "multiple": "Multiple farmers found with name '{value}'.",
+    }
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("queryset", models.Farmer.objects.all())
+        super().__init__(**kwargs)
+
+    def to_internal_value(self, value):
+        if value is None:
+            self.fail("required")
+
+        if isinstance(value, str):
+            value = value.strip()
+
+        if value == "":
+            self.fail("blank")
+
+        if isinstance(value, models.Farmer):
+            return value
+
+        if not isinstance(value, str):
+            self.fail("invalid")
+
+        try:
+            return self.get_queryset().get(name=value)
+        except models.Farmer.DoesNotExist:  # pragma: no cover - simple reraised error
+            self.fail("does_not_exist", value=value)
+        except models.Farmer.MultipleObjectsReturned:  # pragma: no cover - simple reraised error
+            self.fail("multiple", value=value)
+
+    def to_representation(self, value):
+        if isinstance(value, models.Farmer):
+            return value.name
+        return str(value)
+
+
 class FarmerSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Farmer
@@ -12,102 +55,136 @@ class FarmerSerializer(serializers.ModelSerializer):
 
 
 class LandHoldingSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.LandHolding
         fields = "__all__"
 
 
 class AssetSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.Asset
         fields = "__all__"
 
 
 class CropHistorySerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.CropHistory
         fields = "__all__"
 
 
 class CostOfCultivationSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.CostOfCultivation
         fields = "__all__"
 
 
 class WeedSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.Weed
         fields = "__all__"
 
 
 class WaterManagementSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.WaterManagement
         fields = "__all__"
 
 
 class PestDiseaseSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.PestDisease
         fields = "__all__"
 
 
 class NutrientManagementSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.NutrientManagement
         fields = "__all__"
 
 
 class IncomeCropSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.IncomeCrop
         fields = "__all__"
 
 
 class EnterpriseSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.Enterprise
         fields = "__all__"
 
 
 class AnnualFamilyIncomeSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.AnnualFamilyIncome
         fields = "__all__"
 
 
 class MigrationSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.Migration
         fields = "__all__"
 
 
 class AdaptationStrategySerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.AdaptationStrategy
         fields = "__all__"
 
 
 class FinancialSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.Financial
         fields = "__all__"
 
 
 class ConsumptionPatternSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.ConsumptionPattern
         fields = "__all__"
 
 
 class MarketPriceSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.MarketPrice
         fields = "__all__"
 
 
 class IrrigatedRainfedSerializer(serializers.ModelSerializer):
+    farmer = FarmerByNameField()
+
     class Meta:
         model = models.IrrigatedRainfed
         fields = "__all__"

--- a/pmksy/tests/test_import_foreign_keys.py
+++ b/pmksy/tests/test_import_foreign_keys.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import tempfile
+from urllib.parse import parse_qs, urlparse
+
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from data_wizard.models import Run
+
+from ..models import Farmer, LandHolding
+
+
+class ForeignKeyImportTests(TestCase):
+    """Ensure related datasets accept farmer names during import."""
+
+    def setUp(self) -> None:
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="relationtester",
+            email="relationtester@example.com",
+            password="password123",
+        )
+        self.client.force_login(self.user)
+
+        self.farmer = Farmer.objects.create(name="Jane Doe")
+
+        self.wizard_url = reverse(
+            "pmksy:wizard", kwargs={"wizard_slug": "land-holdings"}
+        )
+
+    def test_import_resolves_farmer_name_to_uuid(self) -> None:
+        """Uploading a dataset with farmer names should link to the correct farmer."""
+
+        csv_content = """farmer,category,total_area_ha
+Jane Doe,Small,1.5
+"""
+        upload = SimpleUploadedFile(
+            "land_holdings.csv",
+            csv_content.encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        with tempfile.TemporaryDirectory() as media_root, override_settings(
+            MEDIA_ROOT=media_root
+        ):
+            response = self.client.post(self.wizard_url, {"source_file": upload})
+
+            self.assertEqual(response.status_code, 302)
+            redirect_url = response["Location"]
+            run_id = parse_qs(urlparse(redirect_url).query)["run"][0]
+
+            preview_response = self.client.get(redirect_url)
+            self.assertEqual(preview_response.status_code, 200)
+            self.assertIn("Jane Doe", preview_response.content.decode())
+
+            confirm_response = self.client.post(
+                self.wizard_url, {"run_id": run_id}, follow=True
+            )
+
+        self.assertEqual(confirm_response.status_code, 200)
+        self.assertIn("Import Complete", confirm_response.content.decode())
+
+        land_holding = LandHolding.objects.get()
+        self.assertEqual(land_holding.farmer_id, self.farmer.farmer_id)
+        self.assertEqual(land_holding.category, "Small")
+
+        run = Run.objects.get(pk=int(run_id))
+        record = run.record_set.get()
+        self.assertTrue(record.success)
+        self.assertEqual(record.content_type.model, "landholding")
+        self.assertIn(record.object_id, {None, str(land_holding.land_id)})


### PR DESCRIPTION
## Summary
- add a reusable `FarmerByNameField` that resolves incoming names to Farmer objects with helpful validation
- switch every serializer that references a Farmer foreign key to use the new field so CSV imports accept farmer names
- cover the behavior with a regression test that imports a Land Holding row using the farmer name

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d0d745e6308326b5a602829345fe6f