### PR TITLE
Handle missing farmer values during import

### DIFF
--- a/pmksy/serializers.py
+++ b/pmksy/serializers.py
@@ -9,6 +9,7 @@ class FarmerByNameField(serializers.RelatedField):
     """Serializer field that resolves farmers by their name."""
 
     default_error_messages = {
+        "required": "Farmer name is required.",
         "blank": "Please provide a farmer name.",
         "does_not_exist": "Farmer with name '{value}' does not exist.",
         "invalid": "Invalid farmer name provided.",


### PR DESCRIPTION
## Summary
- add a required error message for `FarmerByNameField` so missing farmer values raise a validation error
- extend the land holding import tests with a scenario where the farmer column is omitted and assert the validation message is reported

## Testing
- python manage.py test pmksy.tests.test_import_foreign_keys

------
https://chatgpt.com/codex/tasks/task_e_68d0ea10f3c88326ae2c6b3efbd3ae6e