### PR TITLE
Handle missing farmer values during import

### DIFF
--- a/pmksy/serializers.py
+++ b/pmksy/serializers.py
@@ -9,6 +9,7 @@ class FarmerByNameField(serializers.RelatedField):
     """Serializer field that resolves farmers by their name."""
 
     default_error_messages = {
+        "required": "Please provide a farmer name.",
         "blank": "Please provide a farmer name.",
         "does_not_exist": "Farmer with name '{value}' does not exist.",
         "invalid": "Invalid farmer name provided.",


### PR DESCRIPTION
## Summary
- add a custom "required" error message to `FarmerByNameField` so missing farmer values raise a validation error
- extend the land holdings import test to cover datasets without a farmer column and assert the friendly error is reported

## Testing
- python manage.py test pmksy.tests.test_import_foreign_keys

------
https://chatgpt.com/codex/tasks/task_e_68d2239eb2c48326841c154bf722e5e5