### PR TITLE
Add upload field guidance to import wizard

### DIFF
--- a/pmksy/templates/pmksy/import_wizard_upload.html
+++ b/pmksy/templates/pmksy/import_wizard_upload.html
@@ -10,6 +10,15 @@
         a { color: #0b5ed7; text-decoration: none; }
         a:hover { text-decoration: underline; }
         .messages { color: #c00; }
+        .field-guidance { margin-top: 1.5rem; padding: 1rem; background: #f5f9ff; border-left: 4px solid #0b5ed7; }
+        .field-guidance p { margin: 0 0 0.5rem; }
+        .field-list { list-style: none; padding: 0; margin: 0; }
+        .field-list li { margin-bottom: 0.75rem; }
+        .field-title { font-weight: 600; display: block; }
+        .field-column { display: inline-block; margin-right: 0.5rem; }
+        code { background: #eef3ff; padding: 0.1rem 0.35rem; border-radius: 3px; }
+        .required-badge { color: #b02a37; font-weight: 600; margin-left: 0.35rem; }
+        .field-note { margin-top: 0.25rem; font-size: 0.9rem; color: #555; }
     </style>
 </head>
 <body>
@@ -22,6 +31,27 @@
                 <li>{{ message }}</li>
             {% endfor %}
         </ul>
+    {% endif %}
+
+    {% if expected_fields %}
+        <section class="field-guidance">
+            <h2>Prepare your file</h2>
+            <p>Include a header row with the following columns. Fields marked <span class="required-badge">Required</span> must be provided.</p>
+            <ul class="field-list">
+                {% for field in expected_fields %}
+                    <li>
+                        <span class="field-title">{{ field.label }}</span>
+                        <span class="field-column">Column name: <code>{{ field.name }}</code></span>
+                        {% if field.required %}
+                            <span class="required-badge">Required</span>
+                        {% endif %}
+                        {% if field.help_text %}
+                            <span class="field-note">{{ field.help_text }}</span>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ul>
+        </section>
     {% endif %}
 
     <form method="post" enctype="multipart/form-data">

--- a/pmksy/tests/test_views.py
+++ b/pmksy/tests/test_views.py
@@ -58,6 +58,16 @@ class PMKSYImportWizardPreviewTests(TestCase):
             any("Failed to generate preview" in message for message in logs.output)
         )
 
+    def test_upload_page_displays_field_guidance(self) -> None:
+        """Users should see guidance describing the expected import columns."""
+
+        response = self.client.get(
+            reverse("pmksy:wizard", kwargs={"wizard_slug": "land-holdings"})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<code>farmer</code>", html=True)
+
 
 class AuthenticationFlowTests(TestCase):
     """Ensure unauthenticated users are prompted to log in before importing."""


### PR DESCRIPTION
## Summary
- compute and cache expected serializer fields for each import wizard and expose them on the upload view
- surface column guidance in the upload template so required fields are easy to identify
- verify the guidance renders by asserting the farmer column appears on the Land Holdings wizard page

## Testing
- python manage.py test pmksy.tests.test_views

------
https://chatgpt.com/codex/tasks/task_e_68d236858aa08326b089219ed1d50566