### PR TITLE
Create shared base template and stylesheet for PMKSY

### DIFF
--- a/pmksy/static/pmksy/app.css
+++ b/pmksy/static/pmksy/app.css
@@ -1,0 +1,193 @@
+body {
+    margin: 0;
+    font-family: "Segoe UI", Arial, sans-serif;
+    line-height: 1.6;
+    color: #212529;
+    background: #f8f9fb;
+}
+
+a {
+    color: #0b5ed7;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+.site-header {
+    background: #0b5ed7;
+    color: #fff;
+    padding: 1.25rem 0;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+.site-title {
+    font-size: 1.75rem;
+    font-weight: 600;
+    display: inline-block;
+}
+
+.site-title:link,
+.site-title:visited {
+    color: #fff;
+}
+
+.site-title:hover {
+    text-decoration: none;
+}
+
+.site-nav ul {
+    list-style: none;
+    margin: 0.75rem 0 0;
+    padding: 0;
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.site-nav a {
+    color: #fff;
+    font-weight: 500;
+}
+
+.page-content {
+    padding: 2rem 0 3rem;
+}
+
+.page-content h1 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 2rem;
+    font-weight: 600;
+}
+
+.page-content p {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.page-content ul {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+}
+
+.page-content li {
+    margin-bottom: 0.5rem;
+}
+
+.messages {
+    color: #b02a37;
+    margin: 1rem 0;
+    padding: 0;
+    list-style: none;
+}
+
+.messages li {
+    margin-bottom: 0.25rem;
+}
+
+form {
+    margin-top: 1.5rem;
+}
+
+.actions {
+    margin-top: 1.5rem;
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+button {
+    background: #0b5ed7;
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1.25rem;
+    border-radius: 4px;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+button:hover {
+    background: #0a53be;
+}
+
+.field-guidance {
+    margin-top: 1.5rem;
+    padding: 1.25rem;
+    background: #f5f9ff;
+    border-left: 4px solid #0b5ed7;
+    border-radius: 4px;
+}
+
+.field-guidance h2 {
+    margin-top: 0;
+}
+
+.field-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.field-list li {
+    margin-bottom: 0.75rem;
+}
+
+.field-title {
+    font-weight: 600;
+    display: block;
+}
+
+.field-column {
+    display: inline-block;
+    margin-right: 0.5rem;
+}
+
+.required-badge {
+    color: #b02a37;
+    font-weight: 600;
+    margin-left: 0.35rem;
+}
+
+.field-note {
+    margin-top: 0.25rem;
+    font-size: 0.9rem;
+    color: #555;
+}
+
+code {
+    background: #eef3ff;
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+}
+
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 1rem;
+    background: #fff;
+}
+
+th,
+td {
+    border: 1px solid #dee2e6;
+    padding: 0.5rem;
+    text-align: left;
+}
+
+th {
+    background: #f1f3f5;
+}
+
+.summary {
+    margin-top: 1.5rem;
+}

--- a/pmksy/templates/pmksy/base.html
+++ b/pmksy/templates/pmksy/base.html
@@ -1,0 +1,28 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}PMKSY Import Wizards{% endblock %}</title>
+    <link rel="stylesheet" href="{% static 'pmksy/app.css' %}">
+    {% block extra_head %}{% endblock %}
+</head>
+<body>
+    <header class="site-header">
+        <div class="container">
+            <a class="site-title" href="{% url 'pmksy:import-home' %}">PMKSY Data Import</a>
+            <nav class="site-nav" aria-label="Primary">
+                <ul>
+                    <li><a href="{% url 'pmksy:import-home' %}">Import home</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main class="page-content">
+        <div class="container">
+            {% block content %}{% endblock %}
+        </div>
+    </main>
+</body>
+</html>

--- a/pmksy/templates/pmksy/home.html
+++ b/pmksy/templates/pmksy/home.html
@@ -1,28 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>PMKSY Import Wizards</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2rem; }
-        h1 { margin-bottom: 1rem; }
-        ul { list-style: none; padding: 0; }
-        li { margin-bottom: 0.5rem; }
-        a { text-decoration: none; color: #0b5ed7; }
-        a:hover { text-decoration: underline; }
-    </style>
-</head>
-<body>
-    <h1>PMKSY Data Import</h1>
-    <p>Select a dataset to begin importing survey records.</p>
-    <ul>
-        {% for wizard in wizards %}
-            <li>
-                <a href="{% url 'pmksy:wizard' wizard.slug %}">{{ wizard.name }}</a>
-            </li>
-        {% empty %}
-            <li>No import wizards are currently configured.</li>
-        {% endfor %}
-    </ul>
-</body>
-</html>
+{% extends "pmksy/base.html" %}
+
+{% block title %}PMKSY Import Wizards{% endblock %}
+
+{% block content %}
+<h1>PMKSY Data Import</h1>
+<p>Select a dataset to begin importing survey records.</p>
+<ul>
+    {% for wizard in wizards %}
+        <li>
+            <a href="{% url 'pmksy:wizard' wizard.slug %}">{{ wizard.name }}</a>
+        </li>
+    {% empty %}
+        <li>No import wizards are currently configured.</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/pmksy/templates/pmksy/import_wizard_preview.html
+++ b/pmksy/templates/pmksy/import_wizard_preview.html
@@ -1,59 +1,46 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>{{ wizard.name }} Preview</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2rem; }
-        table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
-        th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
-        th { background: #f1f3f5; }
-        .actions { margin-top: 1.5rem; display: flex; gap: 1rem; }
-        a { color: #0b5ed7; text-decoration: none; }
-        a:hover { text-decoration: underline; }
-        .messages { color: #c00; }
-    </style>
-</head>
-<body>
-    <h1>{{ wizard.name }} &ndash; Preview Data</h1>
-    <p>Review the first few rows before confirming the import.</p>
+{% extends "pmksy/base.html" %}
 
-    {% if messages %}
-        <ul class="messages">
-            {% for message in messages %}
-                <li>{{ message }}</li>
-            {% endfor %}
-        </ul>
-    {% endif %}
+{% block title %}{{ wizard.name }} Preview{% endblock %}
 
-    {% if rows %}
-        <table>
-            <thead>
+{% block content %}
+<h1>{{ wizard.name }} &ndash; Preview Data</h1>
+<p>Review the first few rows before confirming the import.</p>
+
+{% if messages %}
+    <ul class="messages">
+        {% for message in messages %}
+            <li>{{ message }}</li>
+        {% endfor %}
+    </ul>
+{% endif %}
+
+{% if rows %}
+    <table>
+        <thead>
+            <tr>
+                {% for header in headers %}
+                    <th>{{ header }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in rows %}
                 <tr>
-                    {% for header in headers %}
-                        <th>{{ header }}</th>
+                    {% for value in row %}
+                        <td>{{ value }}</td>
                     {% endfor %}
                 </tr>
-            </thead>
-            <tbody>
-                {% for row in rows %}
-                    <tr>
-                        {% for value in row %}
-                            <td>{{ value }}</td>
-                        {% endfor %}
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% else %}
-        <p>No rows were detected in the uploaded file.</p>
-    {% endif %}
+            {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+    <p>No rows were detected in the uploaded file.</p>
+{% endif %}
 
-    <form method="post" class="actions">
-        {% csrf_token %}
-        {{ confirm_form.as_p }}
-        <button type="submit">Import Records</button>
-        <a href="{% url 'pmksy:wizard' wizard_slug %}">Upload another file</a>
-    </form>
-</body>
-</html>
+<form method="post" class="actions">
+    {% csrf_token %}
+    {{ confirm_form.as_p }}
+    <button type="submit">Import Records</button>
+    <a href="{% url 'pmksy:wizard' wizard_slug %}">Upload another file</a>
+</form>
+{% endblock %}

--- a/pmksy/templates/pmksy/import_wizard_upload.html
+++ b/pmksy/templates/pmksy/import_wizard_upload.html
@@ -1,66 +1,46 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>{{ wizard.name }} Import</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2rem; }
-        form { margin-top: 1.5rem; }
-        .actions { margin-top: 1rem; }
-        a { color: #0b5ed7; text-decoration: none; }
-        a:hover { text-decoration: underline; }
-        .messages { color: #c00; }
-        .field-guidance { margin-top: 1.5rem; padding: 1rem; background: #f5f9ff; border-left: 4px solid #0b5ed7; }
-        .field-guidance p { margin: 0 0 0.5rem; }
-        .field-list { list-style: none; padding: 0; margin: 0; }
-        .field-list li { margin-bottom: 0.75rem; }
-        .field-title { font-weight: 600; display: block; }
-        .field-column { display: inline-block; margin-right: 0.5rem; }
-        code { background: #eef3ff; padding: 0.1rem 0.35rem; border-radius: 3px; }
-        .required-badge { color: #b02a37; font-weight: 600; margin-left: 0.35rem; }
-        .field-note { margin-top: 0.25rem; font-size: 0.9rem; color: #555; }
-    </style>
-</head>
-<body>
-    <h1>{{ wizard.name }} &ndash; Upload File</h1>
-    <p>Upload a CSV, Excel, or JSON file exported from the PMKSY survey.</p>
+{% extends "pmksy/base.html" %}
 
-    {% if messages %}
-        <ul class="messages">
-            {% for message in messages %}
-                <li>{{ message }}</li>
+{% block title %}{{ wizard.name }} Import{% endblock %}
+
+{% block content %}
+<h1>{{ wizard.name }} &ndash; Upload File</h1>
+<p>Upload a CSV, Excel, or JSON file exported from the PMKSY survey.</p>
+
+{% if messages %}
+    <ul class="messages">
+        {% for message in messages %}
+            <li>{{ message }}</li>
+        {% endfor %}
+    </ul>
+{% endif %}
+
+{% if expected_fields %}
+    <section class="field-guidance">
+        <h2>Prepare your file</h2>
+        <p>Include a header row with the following columns. Fields marked <span class="required-badge">Required</span> must be provided.</p>
+        <ul class="field-list">
+            {% for field in expected_fields %}
+                <li>
+                    <span class="field-title">{{ field.label }}</span>
+                    <span class="field-column">Column name: <code>{{ field.name }}</code></span>
+                    {% if field.required %}
+                        <span class="required-badge">Required</span>
+                    {% endif %}
+                    {% if field.help_text %}
+                        <span class="field-note">{{ field.help_text }}</span>
+                    {% endif %}
+                </li>
             {% endfor %}
         </ul>
-    {% endif %}
+    </section>
+{% endif %}
 
-    {% if expected_fields %}
-        <section class="field-guidance">
-            <h2>Prepare your file</h2>
-            <p>Include a header row with the following columns. Fields marked <span class="required-badge">Required</span> must be provided.</p>
-            <ul class="field-list">
-                {% for field in expected_fields %}
-                    <li>
-                        <span class="field-title">{{ field.label }}</span>
-                        <span class="field-column">Column name: <code>{{ field.name }}</code></span>
-                        {% if field.required %}
-                            <span class="required-badge">Required</span>
-                        {% endif %}
-                        {% if field.help_text %}
-                            <span class="field-note">{{ field.help_text }}</span>
-                        {% endif %}
-                    </li>
-                {% endfor %}
-            </ul>
-        </section>
-    {% endif %}
-
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <div class="actions">
-            <button type="submit">Upload &amp; Preview</button>
-            <a href="{% url 'pmksy:import-home' %}">Back to all imports</a>
-        </div>
-    </form>
-</body>
-</html>
+<form method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <div class="actions">
+        <button type="submit">Upload &amp; Preview</button>
+        <a href="{% url 'pmksy:import-home' %}">Back to all imports</a>
+    </div>
+</form>
+{% endblock %}

--- a/pmksy/templates/pmksy/wizard_done.html
+++ b/pmksy/templates/pmksy/wizard_done.html
@@ -1,23 +1,14 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>{{ wizard.name }} Import Complete</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2rem; }
-        .summary { margin-top: 1.5rem; }
-        a { color: #0b5ed7; text-decoration: none; }
-        a:hover { text-decoration: underline; }
-    </style>
-</head>
-<body>
-    <h1>{{ wizard.name }} &ndash; Import Complete</h1>
-    <div class="summary">
-        <p>The uploaded file has been processed. Review the import run for additional details if needed.</p>
-        <p>
-            <a href="{{ run.get_absolute_url }}">View import status</a> |
-            <a href="{% url 'pmksy:import-home' %}">Back to import home</a>
-        </p>
-    </div>
-</body>
-</html>
+{% extends "pmksy/base.html" %}
+
+{% block title %}{{ wizard.name }} Import Complete{% endblock %}
+
+{% block content %}
+<h1>{{ wizard.name }} &ndash; Import Complete</h1>
+<div class="summary">
+    <p>The uploaded file has been processed. Review the import run for additional details if needed.</p>
+    <p>
+        <a href="{{ run.get_absolute_url }}">View import status</a> |
+        <a href="{% url 'pmksy:import-home' %}">Back to import home</a>
+    </p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce a `pmksy/base.html` template with shared layout, navigation, and content blocks
- move repeated inline styling into a new `static/pmksy/app.css` stylesheet referenced by the base template
- update the PMKSY wizard templates to extend the base and keep only page-specific markup

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d23a2d29c4832696364f2866bdddc6