### PR TITLE
Add shared message handling with styled states

### DIFF
--- a/pmksy/static/pmksy/app.css
+++ b/pmksy/static/pmksy/app.css
@@ -83,15 +83,37 @@ a:hover {
     margin-bottom: 0.5rem;
 }
 
-.messages {
-    color: #b02a37;
+.messages-list {
     margin: 1rem 0;
     padding: 0;
     list-style: none;
 }
 
-.messages li {
-    margin-bottom: 0.25rem;
+.messages {
+    margin-bottom: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+    background: #f8f9fb;
+    border-left: 4px solid transparent;
+    color: #212529;
+}
+
+.messages.success {
+    background: #e6f4ea;
+    border-color: #2e7d32;
+    color: #1b5e20;
+}
+
+.messages.warning {
+    background: #fff7e6;
+    border-color: #f57c00;
+    color: #8a4b07;
+}
+
+.messages.error {
+    background: #fdecea;
+    border-color: #d32f2f;
+    color: #7f1d1d;
 }
 
 form {

--- a/pmksy/templates/pmksy/base.html
+++ b/pmksy/templates/pmksy/base.html
@@ -21,6 +21,13 @@
     </header>
     <main class="page-content">
         <div class="container">
+            {% if messages %}
+                <ul class="messages-list">
+                    {% for message in messages %}
+                        <li class="messages {{ message.tags }}">{{ message }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
             {% block content %}{% endblock %}
         </div>
     </main>

--- a/pmksy/templates/pmksy/import_wizard_preview.html
+++ b/pmksy/templates/pmksy/import_wizard_preview.html
@@ -6,14 +6,6 @@
 <h1>{{ wizard.name }} &ndash; Preview Data</h1>
 <p>Review the first few rows before confirming the import.</p>
 
-{% if messages %}
-    <ul class="messages">
-        {% for message in messages %}
-            <li>{{ message }}</li>
-        {% endfor %}
-    </ul>
-{% endif %}
-
 {% if rows %}
     <table>
         <thead>

--- a/pmksy/templates/pmksy/import_wizard_upload.html
+++ b/pmksy/templates/pmksy/import_wizard_upload.html
@@ -6,14 +6,6 @@
 <h1>{{ wizard.name }} &ndash; Upload File</h1>
 <p>Upload a CSV, Excel, or JSON file exported from the PMKSY survey.</p>
 
-{% if messages %}
-    <ul class="messages">
-        {% for message in messages %}
-            <li>{{ message }}</li>
-        {% endfor %}
-    </ul>
-{% endif %}
-
 {% if expected_fields %}
     <section class="field-guidance">
         <h2>Prepare your file</h2>


### PR DESCRIPTION
## Summary
- render Django messages in the shared base template so all pages display feedback consistently
- add contextual success, warning, and error styles for messages
- remove duplicated message loops from the import wizard templates to rely on the base layout

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d253d9ff4c8326909c63277c233aca