### PR TITLE
Adjust registration_id migration defaults

### DIFF
--- a/pmksy/migrations/0003_farmer_registration_id.py
+++ b/pmksy/migrations/0003_farmer_registration_id.py
@@ -33,11 +33,22 @@ class Migration(migrations.Migration):
             name="registration_id",
             field=models.CharField(
                 blank=True,
+                max_length=64,
+                null=True,
+                unique=True,
+            ),
+            preserve_default=False,
+        ),
+        migrations.RunPython(populate_registration_ids, clear_registration_ids),
+        migrations.AlterField(
+            model_name="farmer",
+            name="registration_id",
+            field=models.CharField(
+                blank=True,
                 default=pmksy.models.generate_registration_id,
                 max_length=64,
                 null=True,
                 unique=True,
             ),
         ),
-        migrations.RunPython(populate_registration_ids, clear_registration_ids),
     ]


### PR DESCRIPTION
## Summary
- add the registration_id column without a default so existing farmer rows remain NULL during the schema change
- backfill registration_ids and then restore the generate_registration_id default for future inserts

## Testing
- python manage.py migrate pmksy 0002
- python manage.py dbshell <<'SQL' ...
- python manage.py migrate
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d25fb907708326acc6c97908b63dcb