### PR TITLE
Update CI workflow to rely on requirements install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
-      - name: Install django-data-wizard
-        run: pip install git+https://github.com/wq/django-data-wizard.git
-
       - name: Install dependencies
         run: pip install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django>=5.0,<6.0
 djangorestframework>=3.15.0
-# django-data-wizard does not have a PyPI release; install from GitHub
 data-wizard
 openpyxl>=3.1.0
 tablib[html,xls,xlsx]>=3.5.0


### PR DESCRIPTION
## Summary
- remove the extra step that installed django-data-wizard from GitHub in the CI workflow
- rely on the published PyPI package listed in requirements.txt
- clean up requirements.txt by removing the obsolete comment about the package lacking a PyPI release

## Testing
- pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68d26b1bd35483268601c418bca8992d