### PR TITLE
Add dynamic workbook sheet selection

### DIFF
--- a/pmksy/templates/pmksy/import_wizard_upload.html
+++ b/pmksy/templates/pmksy/import_wizard_upload.html
@@ -63,18 +63,29 @@
     </div>
 
     <div class="form-row{% if form.sheet_name.errors %} has-error{% endif %}">
-        {{ form.sheet_name.label_tag }}
-        {{ form.sheet_name }}
-        {% if form.sheet_name.help_text %}
-            <p class="helptext">{{ form.sheet_name.help_text }}</p>
-        {% endif %}
-        {% if form.sheet_name.errors %}
-            <ul class="errorlist">
-                {% for error in form.sheet_name.errors %}
-                    <li>{{ error }}</li>
-                {% endfor %}
-            </ul>
-        {% endif %}
+        {% with field=form.sheet_name %}
+            {{ field.label_tag }}
+            {% with current_value=field.value %}
+                <select name="{{ field.html_name }}" id="{{ field.id_for_label }}">
+                    <option value=""{% if not current_value %} selected{% endif %}>Select a worksheet</option>
+                    {% for value, label in field.field.choices %}
+                        {% if value %}
+                            <option value="{{ value }}"{% if value == current_value %} selected{% endif %}>{{ label }}</option>
+                        {% endif %}
+                    {% endfor %}
+                </select>
+            {% endwith %}
+            {% if field.help_text %}
+                <p class="helptext">{{ field.help_text }}</p>
+            {% endif %}
+            {% if field.errors %}
+                <ul class="errorlist">
+                    {% for error in field.errors %}
+                        <li>{{ error }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        {% endwith %}
     </div>
 
     <div class="actions">


### PR DESCRIPTION
## Summary
- convert the upload form sheet selector to a dropdown fed by workbook sheet names
- update the upload template to render a placeholder select element with validation feedback
- expand view tests to cover the workbook sheet choice flow and resubmission

## Testing
- python manage.py test pmksy.tests.test_views

------
https://chatgpt.com/codex/tasks/task_e_68d27a54d96483268df28991254b7f19