### PR TITLE
Add farmer registration download view and tests

### DIFF
--- a/pmksy/templates/pmksy/wizard_done.html
+++ b/pmksy/templates/pmksy/wizard_done.html
@@ -11,6 +11,13 @@
         <a href="{{ run.get_absolute_url }}">View import status</a> |
         <a href="{% url 'pmksy:import-home' %}">Back to import home</a>
     </p>
+    {% if wizard_slug == "farmers" %}
+    <p class="download-registrations">
+        <a href="{% url 'pmksy:farmer-registration-download' run.pk %}">
+            Download farmer registration IDs
+        </a>
+    </p>
+    {% endif %}
 </div>
 {% if failure_count %}
 <div class="failure-summary">

--- a/pmksy/urls.py
+++ b/pmksy/urls.py
@@ -11,6 +11,11 @@ urlpatterns = [
     path("", RedirectView.as_view(pattern_name="pmksy:import-home", permanent=False)),
     path("import/", views.ImportHomeView.as_view(), name="import-home"),
     path(
+        "import/farmers/<int:run_id>/registrations.csv",
+        views.FarmerRegistrationDownloadView.as_view(),
+        name="farmer-registration-download",
+    ),
+    path(
         "import/<slug:wizard_slug>/",
         views.PMKSYImportWizard.as_view(),
         name="wizard",


### PR DESCRIPTION
## Summary
- add a farmer registration CSV download view that validates the run and streams registration details
- expose the download route in the UI when the farmers wizard completes
- extend the view test suite to cover downloading the generated registration IDs

## Testing
- python manage.py test pmksy.tests.test_views

------
https://chatgpt.com/codex/tasks/task_e_68d27de804808326ac51184a00e1de5f